### PR TITLE
Force svg-spritemap-webpack-plugin to ^1.0.0 as >=2.0.0 is compatible…

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class SvgSprite {
      * @return {Array}
      */
     dependencies() {
-        return ['svg-spritemap-webpack-plugin'];
+        return ['svg-spritemap-webpack-plugin@^1.0.0'];
     }
 
     /**


### PR DESCRIPTION
… with Webpack 4+ only